### PR TITLE
Feature/develop no dui oidc refresh

### DIFF
--- a/services/conserve-service/src/main/java/se/kth/csc/kmr/conserve/core/ConserveTerms.java
+++ b/services/conserve-service/src/main/java/se/kth/csc/kmr/conserve/core/ConserveTerms.java
@@ -163,7 +163,9 @@ public final class ConserveTerms extends Terms {
 	public static final UUID app = INSTANCE.uuid("http://purl.org/openapp/app");
 
 	public static final UUID provider = INSTANCE.uuid("http://openid.net");
-	
+
+	public static final UUID expiresOn = INSTANCE.uuid("http://purl.org/expiresOn");
+
 	public ConserveTerms() {
 		super(INSTANCE);
 	}

--- a/services/conserve-service/src/main/java/se/kth/csc/kmr/conserve/security/oauth2/OAuth2Endpoints.java
+++ b/services/conserve-service/src/main/java/se/kth/csc/kmr/conserve/security/oauth2/OAuth2Endpoints.java
@@ -244,31 +244,6 @@ public class OAuth2Endpoints {
 			if (user == null) {
 				user = store().in(userContext).sub(userPredicate)
 						.create(userName);
-
-				Graph graph = new GraphImpl();
-				ValueFactory valueFactory = graph.getValueFactory();
-				org.openrdf.model.URI userUri = valueFactory
-						.createURI(store().in(user).uri().toString());
-				graph.add(valueFactory.createStatement(
-						userUri,
-						valueFactory
-								.createURI("http://purl.org/dc/terms/title"),
-						valueFactory.createLiteral(firstName + " "
-								+ lastName)));
-				// email
-				graph.add(valueFactory.createStatement(
-						userUri,
-						valueFactory
-								.createURI("http://xmlns.com/foaf/0.1/mbox"),
-						valueFactory.createURI("mailto:" + email)));
-				// access_token
-				graph.add(valueFactory.createStatement(
-						userUri,
-						valueFactory
-								.createURI("http://xmlns.com/foaf/0.1/openid"),
-						valueFactory.createLiteral(accessToken)));
-				store().in(user).as(ConserveTerms.metadata)
-						.type("application/json").graph(graph);
 				requestNotifier.setResolution(
 						Resolution.StandardType.CONTEXT,
 						store.getConcept(userContext));
@@ -277,6 +252,33 @@ public class OAuth2Endpoints {
 				requestNotifier.doPost();
 
 			}
+
+			// update user claims (name, email, access_token)
+			Graph graph = new GraphImpl();
+			ValueFactory valueFactory = graph.getValueFactory();
+			org.openrdf.model.URI userUri = valueFactory
+					.createURI(store().in(user).uri().toString());
+			graph.add(valueFactory.createStatement(
+					userUri,
+					valueFactory
+							.createURI("http://purl.org/dc/terms/title"),
+					valueFactory.createLiteral(firstName + " "
+							+ lastName)));
+			// email
+			graph.add(valueFactory.createStatement(
+					userUri,
+					valueFactory
+							.createURI("http://xmlns.com/foaf/0.1/mbox"),
+					valueFactory.createURI("mailto:" + email)));
+			// access_token
+			graph.add(valueFactory.createStatement(
+					userUri,
+					valueFactory
+							.createURI("http://xmlns.com/foaf/0.1/openid"),
+					valueFactory.createLiteral(accessToken)));
+			store().in(user).as(ConserveTerms.metadata)
+					.type("application/json").graph(graph);
+
 			Concept session = store().in(sessionContext).sub()
 					.create(randomString());
 			store().in(session)

--- a/services/conserve-service/src/main/java/se/kth/csc/kmr/conserve/security/oauth2/OAuth2Endpoints.java
+++ b/services/conserve-service/src/main/java/se/kth/csc/kmr/conserve/security/oauth2/OAuth2Endpoints.java
@@ -18,12 +18,11 @@
  * #L%
  */
 package se.kth.csc.kmr.conserve.security.oauth2;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.security.SecureRandom;
+import java.util.Date;
 import java.util.UUID;
 import java.util.List;
 import java.sql.Blob;
@@ -31,19 +30,14 @@ import java.sql.Blob;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.*;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.CookieParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.NewCookie;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.core.*;
 import javax.ws.rs.core.Response.Status;
-import  javax.ws.rs.core.Context;
-import org.apache.commons.lang.StringEscapeUtils;
+
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
@@ -51,10 +45,9 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
-import javax.ws.rs.core.UriBuilder;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
-import org.json.JSONTokener;
+import org.json.JSONException;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.json.simple.JSONArray;
@@ -64,12 +57,10 @@ import org.openrdf.model.impl.GraphImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import se.kth.csc.kmr.conserve.Concept;
-import se.kth.csc.kmr.conserve.Content;
-import se.kth.csc.kmr.conserve.Contemp;
-import se.kth.csc.kmr.conserve.Resolution;
+import se.kth.csc.kmr.conserve.*;
 import se.kth.csc.kmr.conserve.core.ConserveTerms;
 import se.kth.csc.kmr.conserve.dsl.ContempDSL;
+import se.kth.csc.kmr.conserve.dsl.ContentDSL;
 import se.kth.csc.kmr.conserve.iface.internal.RequestNotifier;
 import se.kth.csc.kmr.conserve.util.TemplateManager;
 
@@ -129,16 +120,15 @@ public class OAuth2Endpoints {
 	
 	@GET
 	@Path("request")
-	public Response getRequest(@QueryParam("discovery") String openIdUri,
+	public Response getRequest(@QueryParam("discovery") String discoveryUri,
 			@QueryParam("client_id") String client_id,
 			@QueryParam("client_secret") String client_secret,
 			@QueryParam("return") String return_url) {
 		try {
 
 
-			String discoveryUri = openIdUri;
 				DefaultHttpClient httpClient = new DefaultHttpClient();
-				Concept provider = store().in(oidcContext).sub(oidcPredicate).get(openIdUri);
+				Concept provider = store().in(oidcContext).sub(oidcPredicate).get(discoveryUri);
 				if(provider != null && client_secret == null && client_id == null){
 					List<Content> contents = store.getContents(provider.getUuid());
 					for(Content x : contents){
@@ -162,28 +152,37 @@ public class OAuth2Endpoints {
 				if(client_id.equals("") || client_secret.equals("")) return Response.status(404).build();
 
 				
-				HttpGet discovery = new HttpGet(openIdUri);
+				HttpGet discovery = new HttpGet(discoveryUri);
 				HttpResponse response = httpClient.execute(discovery);
 				int status = response.getStatusLine().getStatusCode();
 				if(status>=200 && status < 300){
 					Object obj = JSONValue.parse(EntityUtils.toString(response.getEntity()));
 					JSONObject finalResult = (JSONObject) obj;
-					UriBuilder authorizeUriBuilder = UriBuilder.fromUri(
-							(String) finalResult.get("authorization_endpoint"));
-					authorizeUriBuilder.queryParam("scope","openid profile email");
-					authorizeUriBuilder.queryParam("client_id",client_id);
-					authorizeUriBuilder.queryParam("redirect_uri",uriInfo.getBaseUri().toString()+"o/oauth2/authorize");
-					authorizeUriBuilder.queryParam("response_type","code");
+					// send authentication request
+					// http://openid.net/specs/openid-connect-core-1_0.html#rfc.section.3.1.2.1
 					JSONObject state = new JSONObject();
 					state.put("userinfo_endpoint", (String) finalResult.get("userinfo_endpoint"));
 					state.put("token_endpoint", (String) finalResult.get("token_endpoint"));
 					state.put("client_id",client_id);
 					state.put("client_secret",client_secret);
-					if(return_url!=null){
+					if(return_url!=null)
 						state.put("return_url",return_url);
+					String scopeParam = null;
+					if(((String) finalResult.get("token_endpoint")).indexOf("google") >= 0) {
+						// google has non standard way to retrieve refresh_token
+						// https://developers.google.com/identity/protocols/OpenIDConnect#refresh-tokens
+						scopeParam = "scope=openid+profile+email&access_type=offline&prompt=consent";
+					} else {
+						scopeParam = "scope=openid+profile+email+offline_access";
 					}
-					authorizeUriBuilder.queryParam("state",Base64.encodeBase64URLSafeString(state.toString().getBytes()));
-					return Response.seeOther(authorizeUriBuilder.build()).build();
+					return Response.seeOther(
+							URI.create((String) finalResult.get("authorization_endpoint") +
+									"?" + scopeParam +
+									"&client_id=" + client_id +
+									"&redirect_uri=" + uriInfo.getBaseUri().toString()+"o/oauth2/authorize" +
+									"&response_type=code" +
+									"&state=" + Base64.encodeBase64URLSafeString(state.toString().getBytes())
+							)).build();
 	
 				}
 				else{
@@ -205,23 +204,35 @@ public class OAuth2Endpoints {
 	public Response getAccessToken(@QueryParam("code") String code,
 			@QueryParam("state") String state){
 		try{
+			// extract information for oidc provider
 			Object stateRep = JSONValue.parse (new String(Base64.decodeBase64(state)));
 			JSONObject stateObj = (JSONObject) stateRep;
 			String userEP = (String) stateObj.get("userinfo_endpoint");
 			String tokenEP = (String) stateObj.get("token_endpoint");
 			String clientId = (String) stateObj.get("client_id");
-			String clientSecret = (String) stateObj.get("client_secret"); 
+			String clientSecret = (String) stateObj.get("client_secret");
+
+			// send token request
+			// http://openid.net/specs/openid-connect-core-1_0.html#rfc.section.3.1.3.1
 			HttpClient client = new DefaultHttpClient();
 			HttpPost post = new HttpPost(tokenEP);
-			UriBuilder tokenUriBuilder = UriBuilder.fromUri (tokenEP);
-			StringEntity entity = new StringEntity("grant_type=authorization_code&client_id="+clientId+"&client_secret="+clientSecret+"&code="+code+"&redirect_uri="+uriInfo.getBaseUri().toString()+"o/oauth2/authorize"); //+uriInfo.getBaseUri().toString()+"o/oauth2/authenticate");
-			post.setEntity(entity);
+			post.setEntity( new StringEntity(
+					"grant_type=authorization_code" +
+							"&client_id="+clientId+
+							"&client_secret="+clientSecret+
+							"&code="+code+
+							"&redirect_uri="+uriInfo.getBaseUri().toString()+"o/oauth2/authorize"
+			));
 			post.setHeader("Content-Type","application/x-www-form-urlencoded");
 			HttpResponse response = client.execute(post);
 			Object obj = JSONValue.parse(EntityUtils.toString(response.getEntity()));
 			JSONObject tokenResult = (JSONObject) obj;
 			String accessToken = (String) tokenResult.get("access_token");
+			String refreshToken = (String) tokenResult.get("refresh_token");
 			long expiresIn = Long.parseLong(tokenResult.get("expires_in").toString());
+
+			// send userinfo request
+			// http://openid.net/specs/openid-connect-core-1_0.html#rfc.section.5.3
 			HttpGet userinfoRequest = new HttpGet(userEP);
 			userinfoRequest.setHeader("Authorization", "Bearer " + accessToken);
 			HttpResponse userinfoResponse;
@@ -232,60 +243,61 @@ public class OAuth2Endpoints {
 			String lastName = (String) finalResult.get("family_name");
 			String email = (String) finalResult.get("email");
 			String userName;
-			
+
+			// TODO remove special case for google (migrate database)
 			if(userEP.indexOf("google")>=0) userName = "mailto:" + email;
-			else{
+			else {
 				String sub = (String) finalResult.get("sub");
 				userName = userEP+":"+sub;
 				userName = Base64.encodeBase64URLSafeString(userName.getBytes());
 			}
 
 			Concept user = store().in(userContext).sub().get(userName);
+			Content userContent;
+			org.json.JSONObject userMetadata;
+
 			if (user == null) {
+				// create user in store
 				user = store().in(userContext).sub(userPredicate)
 						.create(userName);
+				userContent = (Content) store().in(user).as(ConserveTerms.metadata).type("application/json");
+				userMetadata = new org.json.JSONObject();
 				requestNotifier.setResolution(
 						Resolution.StandardType.CONTEXT,
 						store.getConcept(userContext));
 				requestNotifier.setResolution(
 						Resolution.StandardType.CREATED, user);
 				requestNotifier.doPost();
-
+			} else {
+				userContent = store().in(user).as(ConserveTerms.metadata).get();
+				userMetadata = new org.json.JSONObject(	store().as(userContent).string() );
 			}
 
-			// update user claims (name, email, access_token)
-			Graph graph = new GraphImpl();
-			ValueFactory valueFactory = graph.getValueFactory();
-			org.openrdf.model.URI userUri = valueFactory
-					.createURI(store().in(user).uri().toString());
-			graph.add(valueFactory.createStatement(
-					userUri,
-					valueFactory
-							.createURI("http://purl.org/dc/terms/title"),
-					valueFactory.createLiteral(firstName + " "
-							+ lastName)));
-			// email
-			graph.add(valueFactory.createStatement(
-					userUri,
-					valueFactory
-							.createURI("http://xmlns.com/foaf/0.1/mbox"),
-					valueFactory.createURI("mailto:" + email)));
-			// access_token
-			graph.add(valueFactory.createStatement(
-					userUri,
-					valueFactory
-							.createURI("http://xmlns.com/foaf/0.1/openid"),
-					valueFactory.createLiteral(accessToken)));
-			store().in(user).as(ConserveTerms.metadata)
-					.type("application/json").graph(graph);
+			// update user claims (name, email, access_token) and used provider (token_endpoint,client_id,client_secret)
+			// but keep refresh_token from last time if no new one
+			// TODO would be better to retrieve provider from store
+			// TODO support non-rdf json in /:index
+			userMetadata
+				.put("http://purl.org/dc/terms/title", firstName + " " + lastName)
+				.put("http://xmlns.com/foaf/0.1/mbox", "mailto:" + email)
+				.put(":access_token", accessToken)
+				.put(":access_token_expiration_date", new java.util.Date().getTime() + 1000*expiresIn)
+				.put(":token_endpoint", tokenEP)
+				.put(":oidc_client_id", clientId)
+				.put(":oidc_client_secret", clientSecret);
+			if (refreshToken != null)
+				userMetadata.put(":refresh_token", refreshToken);
+			store().as(userContent).type("application/json").string(userMetadata.toString());
 
-			Concept session = store().in(sessionContext).sub()
-					.create(randomString());
-			store().in(session)
-					.put(ConserveTerms.reference, user.getUuid());
+			// Create new session and its expiration in store
+			Concept session = store().in(sessionContext).sub().create(randomString());
+			store().in(session).put(ConserveTerms.reference, user.getUuid());
+			store().in(session).as(ConserveTerms.expiresOn).type(MediaType.TEXT_PLAIN).string(
+					Long.toString(new Date().getTime() + 24*60*60*1000));
+
 			NewCookie cookie = new NewCookie("conserve_session",
 					session.getId(), "/", uriInfo.getBaseUri().getHost(),
-					"conserve session id", (int) expiresIn, false);
+					"conserve session id", 1000*60*60*24*7, false);
 			UriBuilder spacereturn = UriBuilder.fromUri(uriInfo.getBaseUri().toString());
 			spacereturn.path(":authentication");
 			spacereturn.queryParam("access_token", accessToken);
@@ -297,6 +309,7 @@ public class OAuth2Endpoints {
 					.header("Cache-Control", "no-store").build();
 		}
 		catch(Exception e){
+			e.printStackTrace();
 			return Response.status(Status.INTERNAL_SERVER_ERROR)
 					.entity(e.getMessage()).type(MediaType.TEXT_PLAIN_TYPE)
 					.build();
@@ -489,6 +502,111 @@ public class OAuth2Endpoints {
 			e.printStackTrace();
 			return null;
 		}
+	}
+
+	@GET
+	@Path("access_token")
+	public Response getAccessToken() {
+
+//		if session is not valid
+//			return 'man you are not logged in!'
+//		if access_token has not expired yet
+//			return access_token
+//		else
+//			request new access_token
+//				if success
+//					return access_token
+//				else
+//					// should not happen
+//					return error: please logout and in
+
+
+		// check session is valid
+		UUID user = null;
+		Concept session = null;
+		javax.servlet.http.Cookie[] cookies = request.getCookies();
+
+		if (cookies != null)
+			for(javax.servlet.http.Cookie cookie : cookies)
+				if("conserve_session".equals(cookie.getName()))
+					session = store.getConcept(sessionContext, cookie.getValue());
+		if (session != null) {
+			if ( new Date().getTime() <= Long.parseLong(
+					((ContentDSL) store().in(session).as(ConserveTerms.expiresOn).get()).string())) {
+				List<Control> sessionReferences = store.getControls(session.getUuid(), ConserveTerms.reference);
+				if (sessionReferences != null && sessionReferences.size() != 0) {
+					user = sessionReferences.get(0).getObject();
+				}
+			}
+		}
+		if (user == null)
+			return Response.status(Status.FORBIDDEN)
+					.entity("Man, you didn't log in!").type(MediaType.TEXT_PLAIN_TYPE)
+					.build();
+
+		// return access_token if it does not expire soon
+		Content userMetadata = store().in(user).as(ConserveTerms.metadata).get();
+		org.json.JSONObject userMetadataJson = null;
+		try {
+			userMetadataJson = new org.json.JSONObject(
+					store().as(userMetadata).string()  );
+
+			if ( ((Long)userMetadataJson.get(":access_token_expiration_date")).longValue() >= new Date().getTime() + 10*60*1000) {
+				return Response.status(Status.OK)
+					.entity(new org.json.JSONObject()
+							.put("access_token",userMetadataJson.get(":access_token"))
+							.put("access_token_expiration_date",userMetadataJson.get(":access_token_expiration_date"))
+							.put("access_token_expires_in",((Long)userMetadataJson.get(":access_token_expiration_date")).longValue() - new Date().getTime())
+							.toString())
+					.type(MediaType.APPLICATION_JSON_TYPE).build();
+			}
+		} catch (JSONException e) {
+			e.printStackTrace();
+			return Response.status(Status.INTERNAL_SERVER_ERROR).build();
+		}
+
+		// access_token has expired or expires soon, so retrieve a new one
+		try {
+			if (!userMetadataJson.has(":refresh_token"))
+				return Response.status(Status.FORBIDDEN).entity("Please logout and login!").build();
+			String clientId = (String) userMetadataJson.get(":oidc_client_id");
+			String clientSecret = (String) userMetadataJson.get(":oidc_client_secret");
+
+			// spec: https://tools.ietf.org/html/rfc6749#section-6
+			HttpClient client = new DefaultHttpClient();
+			HttpPost post = new HttpPost((String) userMetadataJson.get(":token_endpoint"));
+			post.setEntity(	 new StringEntity(
+					"grant_type=refresh_token" +
+							"&refresh_token=" + (String) userMetadataJson.get(":refresh_token")) );
+			post.setHeader("Content-Type","application/x-www-form-urlencoded");
+			post.setHeader("Authorization",
+					"Basic " + java.util.Base64.getEncoder().encodeToString(String.format("%s:%s", clientId, clientSecret).getBytes()) );
+			HttpResponse response = client.execute(post);
+			if (response.getStatusLine().getStatusCode() == 200) {
+				org.json.JSONObject responseBody = new org.json.JSONObject(EntityUtils.toString(response.getEntity()));
+				userMetadataJson
+					.put(":access_token", responseBody.get("access_token"))
+					.put(":access_token_expiration_date", new java.util.Date().getTime() + 1000*(Integer)responseBody.get("expires_in"));
+				store().as(userMetadata).type("application/json").string(userMetadataJson.toString());
+				return Response.ok().entity(new org.json.JSONObject()
+								.put("access_token",userMetadataJson.get(":access_token"))
+								.put("access_token_expiration_date",userMetadataJson.get(":access_token_expiration_date"))
+								.put("access_token_expires_in",((Long)userMetadataJson.get(":access_token_expiration_date")).longValue() - new Date().getTime())
+										.toString()
+						).type(MediaType.APPLICATION_JSON_TYPE).build();
+			} else
+				return Response.status(Status.FORBIDDEN).entity("Please logout and login!").build();
+		} catch (JSONException e) {
+			e.printStackTrace();
+		} catch (UnsupportedEncodingException e) {
+			e.printStackTrace();
+		} catch (ClientProtocolException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		return Response.status(Status.INTERNAL_SERVER_ERROR).build();
 	}
 
 	private static String randomString() {

--- a/services/conserve-service/src/main/java/se/kth/csc/kmr/conserve/security/session/SessionLogin.java
+++ b/services/conserve-service/src/main/java/se/kth/csc/kmr/conserve/security/session/SessionLogin.java
@@ -211,6 +211,7 @@ public class SessionLogin {
 		Concept session = store().in(sessionContext).sub()
 				.create(randomString());
 		store().in(session).put(ConserveTerms.reference, user.getUuid());
+		//TODO set session expiresOn in store
 
 		NewCookie cookie = new NewCookie("conserve_session", session.getId(),
 				"/", uriInfo.getBaseUri().getHost(), "contemp session id",

--- a/services/roleUUPrototype/src/main/webapp/ui/html/authentication.html
+++ b/services/roleUUPrototype/src/main/webapp/ui/html/authentication.html
@@ -81,7 +81,7 @@ if(location.search.indexOf('access_token=')>=0){
 	    			<input type="text" id="oidcName" name="name" placeholder="Name" />
 	    		</div>
 	    		<br>
-    			<input type="checkbox" id="oidcDynamic" name="dynreg"> Try to dynamically register client (only check if you're sure there is no ROLE-SDK client registered on your provider yet)
+    			<input type="checkbox" id="oidcDynamic" name="dynreg"> Try to dynamically register client (only check if you are sure there is no ROLE-SDK client registered on your provider yet)
     			<br>
     			<br>
     			<div>
@@ -261,7 +261,7 @@ if(location.search.indexOf('access_token=')>=0){
 				});
 				
 				$("body").on("click","#gobutton",function(){
-					window.location.assign("/o/oauth2/request?discovery="+document.getElementById("oidcselect").value);	
+					window.location.assign("/o/oauth2/request?discovery="+document.getElementById("oidcselect").value+"&return="+returnUri);
 				});
 			
 				var myvar;


### PR DESCRIPTION
Concept:
- each oidc login:
  - get refresh_token
  - create new session with 24h expiration
- each server request
  - prolong session to 24h
- `GET` `${host}/o/oauth2/access_token`
  - if access_token does not expire soon, return it
  - else refresh access_token and return it

Notes:
- uri building with string concatenation instead of UriBuilder
- renamed "openIdUri" to "discoveryUri"
- replaced Graph with JsonObject: breaks sesame graph (/:index) but is more readable
- longliving browser session cookie (1w)
- `SessionLogin.java` → `login(_)` probably breaking, see `//TODO`
