### PR TITLE
Ajax session

### DIFF
--- a/services/conserve-service/src/main/java/se/kth/csc/kmr/conserve/iface/jaxrs/AllowCorsFilter.java
+++ b/services/conserve-service/src/main/java/se/kth/csc/kmr/conserve/iface/jaxrs/AllowCorsFilter.java
@@ -1,0 +1,46 @@
+package se.kth.csc.kmr.conserve.iface.jaxrs;
+
+import javax.inject.Singleton;
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Created by adabru on 06.03.17.
+ */
+@Singleton
+public class AllowCorsFilter implements Filter {
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        HttpServletResponse res = (HttpServletResponse) servletResponse;
+        HttpServletRequest req = (HttpServletRequest) servletRequest;
+        res.addHeader("Access-Control-Allow-Origin", "*");
+        if(req.getHeader("Origin") != null)
+            res.setHeader("Access-Control-Allow-Origin", req.getHeader("Origin"));
+        res.addHeader("Access-Control-Allow-Methods", "*");
+        res.addHeader("Access-Control-Allow-Headers", req.getHeader("Access-Control-Request-Headers"));
+        res.addHeader("Access-Control-Allow-Credentials", "true");
+        filterChain.doFilter(servletRequest, servletResponse);
+        if(!res.containsHeader("Access-Control-Allow-Origin"))
+            res.addHeader("Access-Control-Allow-Origin", "*");
+        if(req.getHeader("Origin") != null)
+            res.setHeader("Access-Control-Allow-Origin", req.getHeader("Origin"));
+        if(!res.containsHeader("Access-Control-Allow-Methods"))
+            res.addHeader("Access-Control-Allow-Methods", "*");
+        if(!res.containsHeader("Access-Control-Allow-Headers"))
+            res.addHeader("Access-Control-Allow-Headers", req.getHeader("Access-Control-Request-Headers"));
+        if(!res.containsHeader("Access-Control-Allow-Credentials"))
+            res.addHeader("Access-Control-Allow-Credentials", "true");
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+}

--- a/services/conserve-service/src/main/java/se/kth/csc/kmr/conserve/security/oauth2/OAuth2Endpoints.java
+++ b/services/conserve-service/src/main/java/se/kth/csc/kmr/conserve/security/oauth2/OAuth2Endpoints.java
@@ -244,31 +244,6 @@ public class OAuth2Endpoints {
 			if (user == null) {
 				user = store().in(userContext).sub(userPredicate)
 						.create(userName);
-
-				Graph graph = new GraphImpl();
-				ValueFactory valueFactory = graph.getValueFactory();
-				org.openrdf.model.URI userUri = valueFactory
-						.createURI(store().in(user).uri().toString());
-				graph.add(valueFactory.createStatement(
-						userUri,
-						valueFactory
-								.createURI("http://purl.org/dc/terms/title"),
-						valueFactory.createLiteral(firstName + " "
-								+ lastName)));
-				// email
-				graph.add(valueFactory.createStatement(
-						userUri,
-						valueFactory
-								.createURI("http://xmlns.com/foaf/0.1/mbox"),
-						valueFactory.createURI("mailto:" + email)));
-				// access_token
-				graph.add(valueFactory.createStatement(
-						userUri,
-						valueFactory
-								.createURI("http://xmlns.com/foaf/0.1/openid"),
-						valueFactory.createLiteral(accessToken)));
-				store().in(user).as(ConserveTerms.metadata)
-						.type("application/json").graph(graph);
 				requestNotifier.setResolution(
 						Resolution.StandardType.CONTEXT,
 						store.getConcept(userContext));
@@ -277,6 +252,33 @@ public class OAuth2Endpoints {
 				requestNotifier.doPost();
 
 			}
+
+			// update user claims (name, email, access_token)
+			Graph graph = new GraphImpl();
+			ValueFactory valueFactory = graph.getValueFactory();
+			org.openrdf.model.URI userUri = valueFactory
+					.createURI(store().in(user).uri().toString());
+			graph.add(valueFactory.createStatement(
+					userUri,
+					valueFactory
+							.createURI("http://purl.org/dc/terms/title"),
+					valueFactory.createLiteral(firstName + " "
+							+ lastName)));
+			// email
+			graph.add(valueFactory.createStatement(
+					userUri,
+					valueFactory
+							.createURI("http://xmlns.com/foaf/0.1/mbox"),
+					valueFactory.createURI("mailto:" + email)));
+			// access_token
+			graph.add(valueFactory.createStatement(
+					userUri,
+					valueFactory
+							.createURI("http://xmlns.com/foaf/0.1/openid"),
+					valueFactory.createLiteral(accessToken)));
+			store().in(user).as(ConserveTerms.metadata)
+					.type("application/json").graph(graph);
+
 			Concept session = store().in(sessionContext).sub()
 					.create(randomString());
 			store().in(session)

--- a/services/conserve-service/src/main/java/se/kth/csc/kmr/conserve/security/oauth2/OAuth2Endpoints.java
+++ b/services/conserve-service/src/main/java/se/kth/csc/kmr/conserve/security/oauth2/OAuth2Endpoints.java
@@ -53,6 +53,8 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.*;
 import javax.ws.rs.core.Response.Status;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.security.SecureRandom;
 import java.sql.Blob;
 import java.util.List;
@@ -295,6 +297,10 @@ public class OAuth2Endpoints {
 	public Response credulousAuthorize(@HeaderParam("access_token") String accessToken,
 								   @QueryParam("userinfo_endpoint") String userEP) {
 		try {
+			// whitelist oidc provider
+			String oidchost = new URI(userEP).getHost();
+			if(!oidchost.endsWith("learning-layers.eu") && !oidchost.endsWith("googleapis.com"))
+				return Response.status(400).entity("Oidc provider "+oidchost+" not supported").build();
 			// get userinfo from endpoint
 			HttpClient client = new DefaultHttpClient();
 			HttpGet userinfoRequest = new HttpGet(userEP);
@@ -360,6 +366,8 @@ public class OAuth2Endpoints {
 			ex.printStackTrace();
 		} catch(IOException ex) {
 			ex.printStackTrace();
+		} catch (URISyntaxException e) {
+			e.printStackTrace();
 		}
 		return Response.serverError().build();
 	}

--- a/services/resource-service/src/main/java/eu/role_project/service/resource/ResourceModule.java
+++ b/services/resource-service/src/main/java/eu/role_project/service/resource/ResourceModule.java
@@ -27,6 +27,7 @@ import se.kth.csc.kmr.conserve.Responder;
 import se.kth.csc.kmr.conserve.core.ConserveTerms;
 import se.kth.csc.kmr.conserve.core.Contapp;
 import se.kth.csc.kmr.conserve.core.ContempModule;
+import se.kth.csc.kmr.conserve.iface.jaxrs.AllowCorsFilter;
 import se.kth.csc.kmr.conserve.iface.jaxrs.PostRequestFilter;
 import se.kth.csc.kmr.conserve.iface.jaxrs.RequestImpl;
 import se.kth.csc.kmr.conserve.logic.AuthenticationResponder;
@@ -322,6 +323,7 @@ public class ResourceModule extends ServletModule {
 				}).in(Scopes.SINGLETON);
 
 		filter("/*").through(PostRequestFilter.class);
+		filter("/*").through(AllowCorsFilter.class);
 		Map<String, String> h2Params = new HashMap<String, String>();
 		h2Params.put("webAllowOthers", "true");
 		serve("/a/h2*").with(new org.h2.server.web.WebServlet(), h2Params);

--- a/services/roleUUPrototype/src/main/webapp/ui/html/authentication.html
+++ b/services/roleUUPrototype/src/main/webapp/ui/html/authentication.html
@@ -81,7 +81,7 @@ if(location.search.indexOf('access_token=')>=0){
 	    			<input type="text" id="oidcName" name="name" placeholder="Name" />
 	    		</div>
 	    		<br>
-    			<input type="checkbox" id="oidcDynamic" name="dynreg"> Try to dynamically register client (only check if you're sure there is no ROLE-SDK client registered on your provider yet)
+    			<input type="checkbox" id="oidcDynamic" name="dynreg"> Try to dynamically register client (only check if you are sure there is no ROLE-SDK client registered on your provider yet)
     			<br>
     			<br>
     			<div>
@@ -261,7 +261,7 @@ if(location.search.indexOf('access_token=')>=0){
 				});
 				
 				$("body").on("click","#gobutton",function(){
-					window.location.assign("/o/oauth2/request?discovery="+document.getElementById("oidcselect").value);	
+					window.location.assign("/o/oauth2/request?discovery="+document.getElementById("oidcselect").value+"&return="+returnUri);
 				});
 			
 				var myvar;


### PR DESCRIPTION
Create ROLE session with ajax request from other website. Cross origin allowed. Works with Learning Layers and Google. Example:

```
fetch(`${roleUrl}/o/oauth2/authorizeImplicit?userinfo_endpoint=https://api.learning-layers.eu/o/oauth2/userinfo`
  , {credentials: 'include', headers: {"access_token": accessToken}})
```

Same session mechanism as login at ROLE SDK. The session is stored as cookie, fully handled by the ROLE SDK. No additional login required when going to the SDK.